### PR TITLE
Log storage handler trigger in NavBar

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -88,6 +88,7 @@ onMounted(async () => {
     }, 1000)
     // Sync across tabs/windows
     storageHandler = (ev) => {
+        console.log(`NavBar/storageHandler triggered:%s`, ev.key);
         if (ev.key === LAST_RENDER_FETCH_KEY) {
             lastRenderFetchAt.value = readLastFetch()
             console.log(`NavBar/storageHandler lastRenderFetchAt:%s`, lastRenderFetchAt.value);


### PR DESCRIPTION
Add a console.log in NavBar.vue's storageHandler to log the storage event key when triggered. This aids debugging of cross-tab/window synchronization for LAST_RENDER_FETCH_KEY and tracking updates to lastRenderFetchAt.