### PR TITLE
Wait for backend startup; unify fetch errors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { useDoFetch } from '@/components/DoFetch.js';
-import { watch, reactive, ref, onMounted, nextTick } from 'vue'
+import { watch, reactive, ref, onMounted, nextTick, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router';
 const router = useRouter();
 import NavBar from '@/components/NavBar.vue'
@@ -17,7 +17,8 @@ const navHeight = ref(0)
 const updateHeight = () => {
   navHeight.value = navRef.value?.$el.offsetHeight || 0
 }
-
+const backendReady = ref(false);
+const loadingMessage = ref("Starting...");
 //
 // This code handles the following SSE events from the server
 //    sseUserLists - Sent by Init User on initial login and relogin
@@ -273,15 +274,6 @@ watch(
         setupUserSse()
     }
 )
-
-onMounted(async () => {
-  await nextTick()
-  updateHeight()
-
-  // optional: update if window resizes
-  window.addEventListener('resize', updateHeight)
-})
-
 //
 // Verify that the server is available
 //
@@ -297,16 +289,82 @@ async function verifyServerUp() {
         }
     };
     const data = await useDoFetch('verifyServerUp', "/check", options);
-    if (typeof data == 'boolean') {
-        errorsStore.arrayErrors.push({ msg: 'Server not available', param: '' });
-        console.log('verifyServerUp: Error in Fetch verifyServerUp');
-        return
+    if (typeof data == 'boolean') {  
+        // errorsStore.arrayErrors is an array of objects with msg and param
+        // if get boolean then error is in errorsStore.arrayErrors
+        const msg = errorsStore.arrayErrors.length > 0 ? errorsStore.arrayErrors[errorsStore.arrayErrors.length - 1].msg : 'Unknown error';
+        console.log(`verifyServerUp:%s`, JSON.stringify(errorsStore.arrayErrors));
+        return { ready: false,
+            startupStatus: msg,
+            auraStatus: 'unknown',
+            errors: data.startupErrors
+        };
     }
     userData.arrayMinedStatus = data.arrayMinedStatus
     userData.arrayMetadataTypes = data.arrayMetadataTypes
+    return {
+        ready: data.response === "OK",
+        startupStatus: data.startupStatus,
+        auraStatus: data.auraStatus,
+        errors: data.startupErrors
+    };
+
 }
 //
-verifyServerUp()
+function updateLoadingMessage(status) {
+    if (status?.auraStatus === "resuming") {
+        loadingMessage.value = "Warming up database...";
+    } else if (status?.startupStatus === "Starting") {
+        loadingMessage.value = "Starting backend...";
+    } else if (status?.startupStatus === "Failed") {
+        loadingMessage.value = "Startup failed";
+    } else {
+        loadingMessage.value = "Preparing service...";
+    }
+}
+//
+async function waitForBackend(timeoutMs = 5 * 60 * 1000) {
+    const start = Date.now();
+    let delay = 2000;
+    while (true) {
+        if (Date.now() - start > timeoutMs) {
+            throw new Error("Backend startup timeout");
+        }
+        try {
+            const status = await verifyServerUp();
+            if (status.ready) {
+                return status;
+            }
+            updateLoadingMessage(status);
+        } catch (error) {
+            console.error(`App/waitForBackend Error checking backend status:%s`, error);
+            updateLoadingMessage({ startupStatus: "Starting" });
+        }
+        loadingMessage.value += '.';
+        await new Promise(r => setTimeout(r, delay));
+        delay = Math.min(delay + 1000, 8000);
+    }
+}
+//
+onMounted(async () => {
+    await nextTick()
+    updateHeight()
+    // optional: update if window resizes
+    window.addEventListener('resize', updateHeight)
+    try {
+        // wait for backend readiness
+        await waitForBackend();
+        backendReady.value = true;
+    } catch (err) {
+        console.error("Startup failed:", err);
+        loadingMessage.value = "Startup failed";
+    }
+})
+//
+onUnmounted(() => {
+    window.removeEventListener('resize', updateHeight);
+});
+
 </script>
 
 <template>
@@ -314,7 +372,10 @@ verifyServerUp()
         <NavBar  ref="navRef"/>
         <div id="positionModals"></div>
         <div class="container-fluid  app-content">
-            <div class="row justify-content-center">
+            <div v-if="!backendReady">
+                <p>{{ loadingMessage }}</p>
+            </div>
+            <div v-else class="row justify-content-center">
                     <RouterView />
             </div>
         </div>

--- a/src/components/DoFetch.js
+++ b/src/components/DoFetch.js
@@ -22,9 +22,9 @@ export async function useDoFetch (calledFrom, inUrl, options) {
     const fetchPromise = fetch(request);
     const response = await fetchPromise
         .catch (error => {
-            errorsStore.arrayErrors.push({msg : 'Server not available', param : ''});
+            errorsStore.arrayErrors.push({status: 999, msg : 'Server not available', param : ''});
             console.log('useDoFetch ' + calledFrom + ' : Error in event handler::', error);
-            return
+            return false
         });
     // console.log(calledFrom + ": response =", response);
     // iterate over all headers
@@ -40,7 +40,7 @@ export async function useDoFetch (calledFrom, inUrl, options) {
             return data
         }
     } else {
-        errorsStore.arrayErrors.push({msg: response.statusText, param: 'Called from:' + calledFrom + ' - With url:' + response.url});
+        errorsStore.arrayErrors.push({status: response.status,msg: response.statusText, param: 'Called from:' + calledFrom + ' - With url:' + response.url});
     }
     return false        
 }  

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -246,14 +246,6 @@ function resetTroveUser() {
 }
 
 console.log(`HomeView Started`)
-// if (isAuthenticated.value.value && !userData.verifiedTroveUserName) {
-//     console.log(`HomeView Start call getUserTroveIds`)
-//     getUserTroveIds(user.value.value?.nickname)
-// } else {
-//     // Coming back from another tab
-//     console.log(`HomeView Tabbed`)
-//     authUserWithTroveId.value = userData.authUserTroveIds.filter((u) => u.troveUserId != null)
-// }
 </script>
 
 <template>

--- a/src/views/UserMetadataListView.vue
+++ b/src/views/UserMetadataListView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, nextTick, watch, onMounted } from 'vue'
+import { ref, nextTick, watch } from 'vue'
 import ArticleUrls from '@/components/ArticleUrls.vue'
 import { useDoFetch } from '@/components/DoFetch.js';
 import { useErrorsArrayStore } from '@/stores/errorsarray'
@@ -113,42 +113,38 @@ async function getArticleLinks(idxType, idxMetadataValue) {
             'Content-Type': 'application/json'
         }
     };
-    const request = new Request(url, options);
-    const fetchPromise = fetch(request);
-    const response = await fetchPromise
-        .catch(error => {
-            errorsStore.arrayErrors.push({ msg: 'Server not available', param: '' });
-            console.log('UserMetadataListView: Error in event handler:', error);
-            return
-        });
+    const data = await useDoFetch('metadatarticleLinks', url, options);
+    // const request = new Request(url, options);
+    // const fetchPromise = fetch(request);
+    // const response = await fetchPromise
+    //     .catch(error => {
+    //         errorsStore.arrayErrors.push({ msg: 'Server not available', param: '' });
+    //         console.log('UserMetadataListView: Error in event handler:', error);
+    //         return
+    //     });
     // console.log (response);
     // iterate over all headers
     // for (let [key, value] of response.headers) {
     // console.log(`${key} = ${value}`);
     // }
-    if (response.status == 200) {
-        const data = await response.json();
+    // if (response.status == 200) {
+    if (typeof data != 'boolean'){
+        // const data = await response.json();
         console.log('UserMetadataListView/getArticleLinks ', JSON.stringify(data))
         // Update Dup-licate and Ignored modifier
         if (data.linkedArticleUrls.arrayArticleUrls.length > 0) {
             userData.metadataTypeByMetadata[idxType].arrayMetadata[idxMetadataValue].articleListArray = data.linkedArticleUrls.arrayArticleUrls
             console.log('UserMetadataListView/getArticleLinks ', JSON.stringify(userData.metadataTypeByMetadata[idxType].arrayMetadata[idxMetadataValue]))
-            // data.linkedArticleUrls.forEach((el) => {
-            //     el.articleArray.forEach((a, index) => {
-            //         if (a.includes(":")) {
-            //             userData.metadataTypeByMetadata[idxType].arrayMetadata[idxMetadataValue].articleListArray[index].troveArticleId = el
-            //         }
-            //     })
-            // })
-        }
-    } else {
-        console.log('UserMetadataListView ', response)
-        if (response.hasOwnProperty('errors')) {
-            errorsStore.arrayErrors = response.errors
-        } else {
-            errorsStore.arrayErrors.push({ msg: response.statusText, param: response.status });
         }
     }
+    // } else {
+    //     console.log('UserMetadataListView ', response)
+    //     if (response.hasOwnProperty('errors')) {
+    //         errorsStore.arrayErrors = response.errors
+    //     } else {
+    //         errorsStore.arrayErrors.push({ msg: response.statusText, param: response.status });
+    //     }
+    // }
 }
 //
 function flipStoryPrimaryEvent(idxValue) {


### PR DESCRIPTION
App.vue: add backend readiness flow (backendReady, loadingMessage), import onUnmounted, refactor verifyServerUp to return a status object, implement waitForBackend loop with backoff, show loading message until backend is ready, and cleanly remove resize listener on unmount. DoFetch.js: normalize error entries to include a status field (use 999 for network failures) and return false on fetch failure; include status for non-OK responses. UserMetadataListView.vue: remove unused onMounted import and replace inline fetch logic with useDoFetch, handling boolean false results and using returned data; remove old response-handling code. HomeView.vue: remove commented-out startup/tab-handling code. Overall: improve startup robustness and centralize fetch error handling/formatting.