### PR TITLE
Center loading message in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -372,7 +372,7 @@ onUnmounted(() => {
         <NavBar  ref="navRef"/>
         <div id="positionModals"></div>
         <div class="container-fluid  app-content">
-            <div v-if="!backendReady">
+            <div v-if="!backendReady" class="row justify-content-center">
                 <p>{{ loadingMessage }}</p>
             </div>
             <div v-else class="row justify-content-center">


### PR DESCRIPTION
Add Bootstrap classes to the loading container so the "!backendReady" block uses the same row/center alignment as the ready state. This ensures the loadingMessage is horizontally centered within the app layout.