### PR TITLE
2026 june0615

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@ const updateHeight = () => {
   navHeight.value = navRef.value?.$el.offsetHeight || 0
 }
 const backendReady = ref(false);
+let dotInterval;
 const loadingMessage = ref("Starting...");
 //
 // This code handles the following SSE events from the server
@@ -311,6 +312,16 @@ async function verifyServerUp() {
 
 }
 //
+function startDotAnimation() {
+    dotInterval = setInterval(() => {
+        loadingMessage.value += '.';
+    }, 500); // faster UI updates
+}
+//
+function stopDotAnimation() {
+    clearInterval(dotInterval);
+}
+//
 function updateLoadingMessage(status) {
     if (status?.auraStatus === "resuming") {
         loadingMessage.value = "Warming up database...";
@@ -334,9 +345,14 @@ async function waitForBackend(timeoutMs = 5 * 60 * 1000) {
         try {
             const status = await verifyServerUp();
             if (status.ready) {
+                backendReady.value = true;
                 return status;
             }
-            if (JSON.stringify(status) !== JSON.stringify(previousStatus)) {
+            if (status.startupStatus === "Failed") {
+                errorsStore.arrayErrors.push({ msg: status.errors[0], param: JSON.stringify(status.errors) });
+                break
+            }
+            if ((JSON.stringify(status) !== JSON.stringify(previousStatus)) || (loadingMessage.value.length > 20)) {
                 updateLoadingMessage(status);
                 console.log(`App/waitForBackend Status: %s`, JSON.stringify(status));
                 previousStatus = status;
@@ -345,9 +361,10 @@ async function waitForBackend(timeoutMs = 5 * 60 * 1000) {
             console.error(`App/waitForBackend Error checking backend status:%s`, error);
             updateLoadingMessage({ startupStatus: "Starting" });
         }
-        loadingMessage.value += '.';
+        startDotAnimation();
         await new Promise(r => setTimeout(r, delay));
         delay = Math.min(delay + 1000, 8000);
+        stopDotAnimation()
     }
 }
 //
@@ -359,7 +376,6 @@ onMounted(async () => {
     try {
         // wait for backend readiness
         await waitForBackend();
-        backendReady.value = true;
     } catch (err) {
         console.error("Startup failed:", err);
         loadingMessage.value = "Startup failed";

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -1,19 +1,7 @@
 import { shouldUseAuth0 } from './authMode'
 import { useAuth0 } from '@auth0/auth0-vue'
+import * as mock from './mockAuth'
 
-export async function useAuth() {
-    if (shouldUseAuth0) {
-        return useAuth0()
-    }
-    // Dynamic import ensures mockAuth is NOT bundled in production
-    const mock = await import('./mockAuth')
-    return {
-        isAuthenticated: mock.isAuthenticated,
-        isLoading: mock.isLoading,
-        user: mock.user,
-        loginWithRedirect: mock.loginWithRedirect,
-        logout: mock.logout,
-        error: mock.error
-    }
-
- }
+export function useAuth() {
+    return shouldUseAuth0 ? useAuth0() : mock
+}

--- a/src/auth/mockAuth.js
+++ b/src/auth/mockAuth.js
@@ -2,9 +2,9 @@ import { ref } from 'vue'
 import { useDoFetch } from '@/components/DoFetch.js';
 
 export const isLoading = ref(false)   // mockAuth never loads asynchronously
-export const error = ref([])        // no errors by default
+export const error = ref(null)        // no errors by default
 export const isAuthenticated = ref(false)
-export const user = ref({})
+export const user = ref(null)
 export const availableUsers = ref([])
 
 export async function loadMockUsers() {
@@ -42,4 +42,5 @@ export function loginWithRedirect() {
 export function logout() {
     isAuthenticated.value = false
     user.value = null
+    error.value = null
 }

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { useDoFetch } from '@/components/DoFetch.js';
 import { resetServer } from '@/components/ResetUser.js';
-import { ref, watch, onMounted } from 'vue'
+import { ref, watch } from 'vue'
 import { useNavBarStore } from '@/stores/navbar'
 import { useRouter } from 'vue-router';
 const router = useRouter();
@@ -15,7 +15,9 @@ const navBarStore = useNavBarStore()
 const errorsStore = useErrorsArrayStore()
 const userData = useUserDataStore()
 // Status Flag cycle
-// Start - verfiedUser = false
+// Start - userData.verifiedTroveUserName = false
+//
+//
 // User Clicks Login or Signup
 // Triggers call to server to access linked Trove User Id's
 // Check number of linked TroveUserID to this Authenticated User
@@ -55,29 +57,46 @@ var intervalLoading = null
 const verifyChgPrompt = 'Verify Changed User'
 //
 // const isLoading = ref(false)
-const isAuthenticated = ref(false)
-const error = ref([])
-const loginWithRedirect = ref(null)
-const user = ref(null)
+// const isAuthenticated = ref(false)
+// const error = ref([])
+// const loginWithRedirect = ref(null)
+// const user = ref(null)
 
-onMounted(async () => {
-    const auth = await useAuth()
-    isAuthenticated.value = auth.isAuthenticated
-    error.value = auth.error
-    loginWithRedirect.value = auth.loginWithRedirect
-    user.value = auth.user
+// onMounted(async () => {
+//     const auth = await useAuth()
+//     isAuthenticated.value = auth.isAuthenticated
+//     error.value = auth.error
+//     loginWithRedirect.value = auth.loginWithRedirect
+//     user.value = auth.user
 
-    console.log(`HomeView Start onMounted isAuthenticated-%s, verifiedTroveUserID-%s user-%s`, isAuthenticated.value.value, userData.verifiedTroveUserName, JSON.stringify(user.value.value))
-    watch(() => user.value.value, async (u) => {
-        console.log("HomeView trigger user watch:", u)
-        if (u && !userData.verifiedTroveUserName) {
-            await getUserTroveIds(user.value.value?.nickname)
-        }
-    })
-    watch(error, (err) => {
-        if (err) console.error("HomeView Auth0 error:", err)
-    })
-})
+//     console.log(`HomeView Start onMounted isAuthenticated-%s, verifiedTroveUserID-%s user-%s`, isAuthenticated.value.value, userData.verifiedTroveUserName, JSON.stringify(user.value.value))
+//     watch(() => user.value.value, async (u) => {
+//         console.log("HomeView trigger user watch:", u)
+//         if (u && !userData.verifiedTroveUserName) {
+//             await getUserTroveIds(user.value?.nickname)
+//         }
+//     })
+//     watch(error, (err) => {
+//         if (err) console.error("HomeView Auth0 error:", err)
+//     })
+// })
+
+const auth = useAuth()
+const user = auth.user
+const error = auth.error
+const isAuthenticated = auth.isAuthenticated
+const loginWithRedirect = auth.loginWithRedirect
+
+watch(user, async (u) => {
+    console.log("HomeView trigger user watch:", u)
+    if (u && !userData.verifiedTroveUserName) {
+        await getUserTroveIds(u.nickname)
+    }
+}, { immediate: true })
+
+watch(error, (err) => {
+    if (err) console.error("HomeView Auth0 error:", err)
+}, { immediate: true })
 
 const login = () => loginWithRedirect.value()
 const signup = () =>
@@ -111,7 +130,7 @@ watch(
         clearInterval(intervalLoading);
         intervalLoading = null;
         navBarStore.disableTroveLists = false;
-        console.log(`HomeView Watch: Good TO Go - Is Authenticated:%s, Verified User:%s`, isAuthenticated.value.value, userData.verifiedTroveUserName)
+        console.log(`HomeView Watch: Good TO Go - Is Authenticated:%s, Verified User:%s`, isAuthenticated.value, userData.verifiedTroveUserName)
         // If this was a Browser Reload from Server - Check if the full load never completed
         // Indicated by last list that is not a duplicate having a count > 0 but no artices in its Article Array
         //  force a refresh
@@ -136,7 +155,6 @@ watch(
 //
 async function getUserTroveIds(authUserName) {
     // oauth will populate user
-    // isLoading.value.value = true
     loadingMsg.value = loadingAuthMsg
     loadingTick();
     errorsStore.arrayErrors = [];
@@ -161,7 +179,6 @@ async function getUserTroveIds(authUserName) {
         // Verification failed
         loadingTroveUseData.value = false
     } else {
-        // isLoading.value.value = false
         userData.authUserTroveIds = [...data]
         userData.verifiedAuthUserName = true
         navBarStore.disableManage = false
@@ -249,7 +266,7 @@ console.log(`HomeView Started`)
 </script>
 
 <template>
-    <div v-if="!isAuthenticated.value" class="card col-sm-4 text-center">
+    <div v-if="!isAuthenticated" class="card col-sm-4 text-center">
         <MockLogin v-if="!shouldUseAuth0" />
         <template v-else>
             <br>
@@ -263,7 +280,7 @@ console.log(`HomeView Started`)
             <button @click="signup" class="btn btn-secondary mt-2">Signup an Authentication User Name</button>
         </template>
     </div>
-    <div v-else-if="isAuthenticated.value && !userData.verifiedTroveUserName" class="card col-sm-4 text-center">
+    <div v-else-if="isAuthenticated && !userData.verifiedTroveUserName" class="card col-sm-4 text-center">
         <p v-if="'troveUserId' in userData.troveDetails">
             Change {{ userData.troveDetails.troveUserId }} to Manage Another
         </p>


### PR DESCRIPTION
Replace dynamic mock import with a synchronous mock export and simplify useAuth to return either Auth0 or the mock. Update mockAuth defaults (user/error -> null) and clear error on logout. Adjust HomeView to use useAuth() synchronously (remove async onMounted flow), wire up auth refs directly, use immediate watchers, remove unused onMounted import, and fix template bindings to check isAuthenticated directly. Minor logging and cleanup included.
Add a dot animation for the loading message (startDotAnimation/stopDotAnimation) with faster 500ms updates and ensure the interval is cleared. Move setting of backendReady to when the server reports ready. In waitForBackend, detect a startup "Failed" status and record the error to errorsStore, break the loop, and update loading messages only on meaningful changes (or when the loading text grows too long). Remove the redundant backendReady assignment in onMounted. These changes make startup feedback more responsive and surface backend startup failures to the UI.