### PR TITLE
Add guards and enhanced logging to user watcher

### DIFF
--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -88,8 +88,16 @@ const isAuthenticated = auth.isAuthenticated
 const loginWithRedirect = auth.loginWithRedirect
 
 watch(user, async (u) => {
-    console.log("HomeView trigger user watch:", u)
-    if (u && !userData.verifiedTroveUserName) {
+    console.log(`HomeView WATCH user:%s, userData:%s`, JSON.stringify(u), JSON.stringify(userData))
+    if (!u) {
+        console.log("HomeView WATCH userSkipping: no user yet")
+        return
+    }
+    if (!userData) {
+        console.log("HomeView WATCH userSkipping: no userData yet")
+        return
+    }
+    if (!userData.verifiedTroveUserName) {
         await getUserTroveIds(u.nickname)
     }
 }, { immediate: true })


### PR DESCRIPTION
Enhance the user watcher with more detailed logging and early-return guards. The console log now prints user and userData as JSON for debugging; the watcher returns early if user or userData is not present to avoid runtime errors during initial load. getUserTroveIds is only invoked when userData exists and verifiedTroveUserName is missing.