### PR TITLE
2026 jul1303

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -338,6 +338,7 @@ async function waitForBackend(timeoutMs = 5 * 60 * 1000) {
     const start = Date.now();
     let delay = 2000;
     var previousStatus = null;
+    startDotAnimation();
     while (true) {
         if (Date.now() - start > timeoutMs) {
             throw new Error("Backend startup timeout");
@@ -346,6 +347,7 @@ async function waitForBackend(timeoutMs = 5 * 60 * 1000) {
             const status = await verifyServerUp();
             if (status.ready) {
                 backendReady.value = true;
+                stopDotAnimation()
                 return status;
             }
             if (status.startupStatus === "Failed") {
@@ -361,19 +363,19 @@ async function waitForBackend(timeoutMs = 5 * 60 * 1000) {
             console.error(`App/waitForBackend Error checking backend status:%s`, error);
             updateLoadingMessage({ startupStatus: "Starting" });
         }
-        startDotAnimation();
         await new Promise(r => setTimeout(r, delay));
         delay = Math.min(delay + 1000, 8000);
-        stopDotAnimation()
     }
 }
 //
 onMounted(async () => {
+    console.log(`App/onMounted Start`);
     await nextTick()
     updateHeight()
     // optional: update if window resizes
     window.addEventListener('resize', updateHeight)
     try {
+        console.log(`App/onMounted waitForBackend`);
         // wait for backend readiness
         await waitForBackend();
     } catch (err) {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -48,13 +48,14 @@ const userData = useUserDataStore()
 var userReloadLists = false // Browser restart - User Verified - Session On Server to reload from
 const loadingAuthMsg = 'Authenticating .'
 const loadingTroveMsg = 'Loading from TROVE .'
+var currentLoadingMsg = ''
 const loadingMsg = ref('')
-const authUserWithTroveId = ref([])
+const authUserTroveIds = ref([])
 const selectedTroveUserId = ref('')
 const loadingTroveUseData = ref(false) // Shows / Hides loadingMsg
 var inUserId = ''
 var intervalLoading = null
-const verifyChgPrompt = 'Verify Changed User'
+// const verifyChgPrompt = 'Verify Changed User'
 
 const auth = useAuth()
 const user = auth.user
@@ -64,7 +65,7 @@ const loginWithRedirect = auth.loginWithRedirect
 
 console.log(`HomeView Start isAuthenticated-%s, verifiedTroveUserID-%s user-%s`, isAuthenticated.value, userData.verifiedTroveUserName, user?.value)
 watch(user, async (u) => {
-    console.log(`HomeView WATCH user:%s, userData:%s`, u, userData?.verifiedTroveUserName)
+    console.log(`HomeView WATCH user:%s, userData:%s`, JSON.stringify(u), userData?.verifiedTroveUserName)
     if (!u) {
         console.log("HomeView WATCH userSkipping: no user yet")
         return
@@ -103,6 +104,9 @@ function loadingTick() {
 }
 function tick() {
     loadingMsg.value += '.';
+    if (loadingMsg.value.length > 20) {
+        loadingMsg.value = currentLoadingMsg
+    }
 }
 // Asynch method in App.vue will set this
 watch(
@@ -140,6 +144,7 @@ watch(
 async function getUserTroveIds(authUserName) {
     // oauth will populate user
     loadingMsg.value = loadingAuthMsg
+    currentLoadingMsg = loadingAuthMsg
     loadingTick();
     errorsStore.arrayErrors = [];
     console.log('HomeView/getUserTroveIds User-', authUserName)
@@ -166,18 +171,18 @@ async function getUserTroveIds(authUserName) {
         userData.authUserTroveIds = [...data]
         userData.verifiedAuthUserName = true
         navBarStore.disableManage = false
-        console.log(`HomeView/getUserTroveIds Returned userData.authUserTroveIds: %s `, userData?.authUserTroveIds)
+        console.log(`HomeView/getUserTroveIds Returned userData.authUserTroveIds: %s `, JSON.stringify(userData?.authUserTroveIds))
         // How many Trove User ID's are linked to this AuthUser
-        authUserWithTroveId.value = userData.authUserTroveIds.filter((u) => u.troveUserId != null)
-        console.log(`HomeView/getUserTroveIds Returned authUserWithTroveId: %s `, authUserWithTroveId?.value)
-        switch (authUserWithTroveId.value.length) {
+        authUserTroveIds.value = userData.authUserTroveIds.filter((u) => u.troveUserId != null)
+        console.log(`HomeView/getUserTroveIds Returned authUserTroveIds: %s `, JSON.stringify(authUserTroveIds?.value))
+        switch (authUserTroveIds.value.length) {
             case 0: // Ask User to link one in Manage
                 userData.authUserTroveIds[0].troveUserId = ''
                 userData.authUserTroveIds[0].troveUserApiKey = ''
                 router.push({ name: 'manage' })
                 break
             case 1: // If only one then use that as Trove User Id
-                inUserId = authUserWithTroveId.value[0].troveUserId
+                inUserId = authUserTroveIds.value[0].troveUserId
                 userData.verifiedTroveUserName = true
                 console.log(`HomeView/getUserTroveIds Direct verifyTroveUser: %s `, inUserId)
                 verifyTroveUser(false)
@@ -222,6 +227,7 @@ async function verifyTroveUser(refresh) {
             userReloadLists = true;
         }
         loadingMsg.value = loadingTroveMsg
+        currentLoadingMsg = loadingTroveMsg
         loadingTick();
     }
 }
@@ -242,7 +248,7 @@ function resetTroveUser() {
     console.log('resetTroveUser')
     userData.verifiedTroveUserName = false
     inUserId = ''
-    verifyUserPrompt = verifyChgPrompt
+    // verifyUserPrompt = verifyChgPrompt
     resetServer()
 }
 
@@ -283,7 +289,7 @@ console.log(`HomeView Started`)
                         <button @click.prevent="refreshUserLists()" class="btn btn-primary">Refresh
                             Your Trove Lists</button>
                     </div>
-                    <div v-if="userData?.userListsReady && (authUserWithTroveId?.length > 1)">
+                    <div v-if="userData?.userListsReady && (authUserTroveIds?.length > 1)">
                         <button @click.prevent="userData.verifiedTroveUserName = false" class="btn btn-primary">Change
                             User</button>
                     </div>
@@ -296,7 +302,7 @@ console.log(`HomeView Started`)
                     <!-- Trove User Id selection, fires watcher on selected UI -->
                     <select v-model="selectedTroveUserId">
                         <option disabled value="">-- Select a Trove User Id --</option>
-                        <option v-for="u in authUserWithTroveId  ?? []" :key="u.id" :value="u.troveUserId">
+                        <option v-for="u in authUserTroveIds  ?? []" :key="u.id" :value="u.troveUserId">
                             {{ u.troveUserId }}
                         </option>
                     </select>

--- a/src/views/ManageView.vue
+++ b/src/views/ManageView.vue
@@ -2,15 +2,15 @@
 import { useDoFetch } from '@/components/DoFetch.js';
 import { ref } from 'vue'
 import EditItem from '@/components/EditItem.vue'
-import { useRouter } from 'vue-router';
-const router = useRouter();
-import NavBar from '@/components/NavBar.vue'
-import { useErrorsArrayStore } from '@/stores/errorsarray'
-const errorsStore = useErrorsArrayStore()
+// import { useRouter } from 'vue-router';
+// const router = useRouter();
+// import NavBar from '@/components/NavBar.vue'
+// import { useErrorsArrayStore } from '@/stores/errorsarray'
+// const errorsStore = useErrorsArrayStore()
 import { useUserDataStore } from '@/stores/userdata'
 const userData = useUserDataStore()
-import { useNavBarStore } from '@/stores/navbar'
-const navStore = useNavBarStore()
+// import { useNavBarStore } from '@/stores/navbar'
+// const navStore = useNavBarStore()
 //
 var notifyEditError = ref('inherit')
 var popoverForTroveId = ref('')
@@ -54,6 +54,7 @@ async function validateInput(action, index) {
             } else {
                 if ((index > userData.authUserTroveIds.length - 1) ||
                     (localAuthUserTroveIds.value[index].troveUserId != userData.authUserTroveIds[index].troveUserId)) {
+                    console.log(`ManageView/validateInput index:%s Check:%s`, index, localAuthUserTroveIds.value[index].troveUserId)
                     // Validate the entered Trove Id
                     const chkedTroveUserId = await ckhTroveUserId(localAuthUserTroveIds.value[index].troveUserId)
                     if (!chkedTroveUserId.validTroveUserId) {
@@ -108,9 +109,9 @@ async function validateInput(action, index) {
 //
 //  Check if troveUserId is valid and not linked to another authUserName
 async function ckhTroveUserId(chkTroveUserId) {
-    console.log("ManageView/ckhTroveUserId ", chkTroveUserId)
+    console.log(`ManageView/ckhTroveUserId AuthUserName:%s, Check Trove USer Id:%s`, userData.authUserTroveIds[0]?.authUserName, chkTroveUserId)
     var updatedData = {
-        'troveUserId': userData.troveDetails.troveUserId,
+        'authUserName': userData.authUserTroveIds[0]?.authUserName,
         'chkTroveUserId': chkTroveUserId
     }
     // console.log (updatedData);
@@ -295,14 +296,14 @@ async function saveData() {
                     </tr>
                 </thead>
                 <tbody>
-                    <tr v-for="(troveId, index) in localAuthUserTroveIds">
+                    <tr v-for="(troveId, index) in localAuthUserTroveIds" :key="index">
                         <template v-if="editTroveId > -1"> <!-- In Edit Mode-->
                             <template v-if="editTroveId == index"> <!-- Row to Edit -->
                                 <td :style="{ 'background-color': notifyEditError }"> <!-- Trove Id -->
-                                    <input v-model="troveId.troveUserId" placeholder="Enter a Trove Id">
-                                    <span v-if="popoverForTroveId.length > 0" class="tooltiptext">{{ popoverForTroveId
-                                    }}</span>
-                                    </input>
+                                    <div>
+                                        <input v-model="troveId.troveUserId" placeholder="Enter a Trove Id">
+                                        <span v-if="popoverForTroveId.length > 0" class="tooltiptext">{{ popoverForTroveId }}</span>
+                                    </div>
                                 </td>
                                 <td> <!-- troveUserApiKey -->
                                     <input v-model="troveId.troveUserApiKey" placeholder="Enter a Trove API Key" />


### PR DESCRIPTION
[Start dot animation before backend wait](https://github.com/pmm57/pmmtrove-ui/commit/de16392dd92836871938c2e912384ae14fd56971) 

Call startDotAnimation() once before entering waitForBackend's loop and stop it when the backend becomes ready (stopDotAnimation()). This removes the repeated start/stop calls inside the loop to avoid redundant animation toggles. Also added console.log traces in onMounted ("App/onMounted Start" and "App/onMounted waitForBackend") to aid startup debugging.
[Refactor Trove ID handling and minor UI fixes](https://github.com/pmm57/pmmtrove-ui/commit/3fe2be30010eaea9f7f4729709afbfe0427d38b7) 

Rename and centralize Trove ID state (authUserWithTroveId -> authUserTroveIds) and update templates/watchers to use the new ref. Add currentLoadingMsg and trim excessive loading dots to avoid long loading strings. Improve debug output by JSON.stringify-ing user and arrays, comment out unused imports and prompts, and add extra debug logs in ManageView. Fix ckhTroveUserId payload to include authUserName, add :key to v-for rows, and correct input markup inside the table row.